### PR TITLE
feat(projen-transitive): retrieve projen as a transitive dependency and not a direct one

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,4 +1,3 @@
-import { DependencyType } from 'projen';
 import { TypescriptLibraryProject } from './src';
 
 const project = new TypescriptLibraryProject({
@@ -7,5 +6,4 @@ const project = new TypescriptLibraryProject({
   deps: ['projen'],
 });
 project.deps.removeDependency('@gplassard/projen-extensions');
-project.deps.removeDependency('projen', DependencyType.BUILD);
 project.synth();

--- a/src/typescript/TypescriptApplicationProject.ts
+++ b/src/typescript/TypescriptApplicationProject.ts
@@ -1,4 +1,4 @@
-import { JsonPatch } from 'projen';
+import { DependencyType, JsonPatch } from 'projen';
 import { GithubCredentials } from 'projen/lib/github';
 import { AppPermission } from 'projen/lib/github/workflows-model';
 import { TypeScriptCompilerOptions, UpgradeDependenciesSchedule } from 'projen/lib/javascript';
@@ -62,6 +62,8 @@ export class TypescriptApplicationProject extends TypeScriptProject {
       },
     };
     super(typescriptProjectOptions);
+    // we get it through a transitive dependency to @gplassard/projen-extensions, maybe should be a peer dependency instead
+    this.deps.removeDependency('projen', DependencyType.BUILD);
     new CustomGitignore(this, options.customGitignore);
 
     if (typescriptProjectOptions.jestOptions?.configFilePath) {

--- a/test/typescript/__snapshots__/TypescriptApplicationProject.test.ts.snap
+++ b/test/typescript/__snapshots__/TypescriptApplicationProject.test.ts.snap
@@ -707,10 +707,6 @@ tsconfig.tsbuildinfo
         "version": "^16",
       },
       {
-        "name": "projen",
-        "type": "build",
-      },
-      {
         "name": "standard-version",
         "type": "build",
         "version": "^9",
@@ -1283,7 +1279,6 @@ tsconfig.tsbuildinfo
       "jest": "*",
       "jest-junit": "^15",
       "npm-check-updates": "^16",
-      "projen": "*",
       "standard-version": "^9",
       "ts-jest": "*",
       "ts-node": "*",

--- a/test/typescript/__snapshots__/TypescriptLibraryProject.test.ts.snap
+++ b/test/typescript/__snapshots__/TypescriptLibraryProject.test.ts.snap
@@ -733,10 +733,6 @@ tsconfig.tsbuildinfo
         "version": "^16",
       },
       {
-        "name": "projen",
-        "type": "build",
-      },
-      {
         "name": "standard-version",
         "type": "build",
         "version": "^9",
@@ -1345,7 +1341,6 @@ tsconfig.tsbuildinfo
       "jest": "*",
       "jest-junit": "^15",
       "npm-check-updates": "^16",
-      "projen": "*",
       "standard-version": "^9",
       "ts-jest": "*",
       "ts-node": "*",


### PR DESCRIPTION
Fixes #